### PR TITLE
Moving handle_captcha code into separate function

### DIFF
--- a/aws_google_auth/google.py
+++ b/aws_google_auth/google.py
@@ -11,7 +11,6 @@ import base64
 from bs4 import BeautifulSoup
 from PIL import Image
 from six.moves import urllib_parse, input
-from six.moves.urllib.request import urlopen
 from six import print_ as print
 
 # The U2F USB Library is optional, if it's there, include it.
@@ -314,8 +313,8 @@ class Google:
         captcha_url_audio = captcha_container.find('input', {'name': 'url_audio'}).get('value')
 
         # Open captcha image
-        with urlopen(captcha_url) as url:
-            with io.BytesIO(url.read()) as f:
+        with requests.get(captcha_url) as url:
+            with io.BytesIO(url.content) as f:
                 Image.open(f).show()
 
         try:

--- a/aws_google_auth/google.py
+++ b/aws_google_auth/google.py
@@ -208,57 +208,11 @@ class Google:
 
         self.check_extra_step(response_page)
 
+        # Process Google CAPTCHA verification request if present
         if cap is not None:
             self.session.headers['Referer'] = sess.url
 
-            # Collect ProfileInformation, SessionState, signIn, and Password Challenge URL
-            challenge_page = response_page
-
-            profile_information = challenge_page.find('input', {
-                'name': 'ProfileInformation'
-            }).get('value')
-            session_state = challenge_page.find('input', {
-                'name': 'SessionState'
-            }).get('value')
-            sign_in = challenge_page.find('input', {'name': 'signIn'}).get('value')
-            passwd_challenge_url = challenge_page.find('form', {
-                'id': 'gaia_loginform'
-            }).get('action')
-
-            # Update the payload
-            payload['SessionState'] = session_state
-            payload['ProfileInformation'] = profile_information
-            payload['signIn'] = sign_in
-            payload['Passwd'] = self.config.password
-
-            # Get all captcha challenge tokens and urls
-            captcha_container = challenge_page.find('div', {'class': 'captcha-container'})
-            captcha_logintoken = captcha_container.find('input', {'name': 'logintoken'}).get('value')
-            captcha_url = captcha_container.find('input', {'name': 'url'}).get('value')
-            captcha_logintoken_audio = captcha_container.find('input', {'name': 'logintoken_audio'}).get('value')
-            captcha_url_audio = captcha_container.find('input', {'name': 'url_audio'}).get('value')
-
-            # Open captcha image
-            url = urlopen(captcha_url)
-            f = io.BytesIO(url.read())
-            url.close()
-            img = Image.open(f)
-            img.show()
-
-            try:
-                captcha_input = raw_input("Captcha (case insensitive): ") or None
-            except NameError:
-                captcha_input = input("Captcha (case insensitive): ") or None
-
-            # Update the payload
-            payload['logincaptcha'] = captcha_input
-            payload['logintoken'] = captcha_logintoken
-            payload['url'] = captcha_url
-            payload['logintoken_audio'] = captcha_logintoken_audio
-            payload['url_audio'] = captcha_url_audio
-
-            # POST to Authenticate Password
-            sess = self.post(passwd_challenge_url, data=payload)
+            sess = self.handle_captcha(sess, payload)
 
             response_page = BeautifulSoup(sess.text, 'html.parser')
             error = response_page.find(class_='error-msg')
@@ -330,6 +284,53 @@ class Google:
                 'Could not find SAML response, check your credentials')
 
         return base64.b64decode(saml_element)
+
+    def handle_captcha(self, sess, payload):
+        response_page = BeautifulSoup(sess.text, 'html.parser')
+
+        # Collect ProfileInformation, SessionState, signIn, and Password Challenge URL
+        profile_information = response_page.find('input', {
+            'name': 'ProfileInformation'
+        }).get('value')
+        session_state = response_page.find('input', {
+            'name': 'SessionState'
+        }).get('value')
+        sign_in = response_page.find('input', {'name': 'signIn'}).get('value')
+        passwd_challenge_url = response_page.find('form', {
+            'id': 'gaia_loginform'
+        }).get('action')
+
+        # Update the payload
+        payload['SessionState'] = session_state
+        payload['ProfileInformation'] = profile_information
+        payload['signIn'] = sign_in
+        payload['Passwd'] = self.config.password
+
+        # Get all captcha challenge tokens and urls
+        captcha_container = response_page.find('div', {'class': 'captcha-container'})
+        captcha_logintoken = captcha_container.find('input', {'name': 'logintoken'}).get('value')
+        captcha_url = captcha_container.find('input', {'name': 'url'}).get('value')
+        captcha_logintoken_audio = captcha_container.find('input', {'name': 'logintoken_audio'}).get('value')
+        captcha_url_audio = captcha_container.find('input', {'name': 'url_audio'}).get('value')
+
+        # Open captcha image
+        with urlopen(captcha_url) as url:
+            with io.BytesIO(url.read()) as f:
+                Image.open(f).show()
+
+        try:
+            captcha_input = raw_input("Captcha (case insensitive): ") or None
+        except NameError:
+            captcha_input = input("Captcha (case insensitive): ") or None
+
+        # Update the payload
+        payload['logincaptcha'] = captcha_input
+        payload['logintoken'] = captcha_logintoken
+        payload['url'] = captcha_url
+        payload['logintoken_audio'] = captcha_logintoken_audio
+        payload['url_audio'] = captcha_url_audio
+
+        return self.post(passwd_challenge_url, data=payload)
 
     def handle_sk(self, sess):
         response_page = BeautifulSoup(sess.text, 'html.parser')

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ beautifulsoup4
 boto3
 configparser
 lxml
-requests
-tabulate
-six
 Pillow
+requests
+six
+tabulate

--- a/setup.py
+++ b/setup.py
@@ -84,8 +84,8 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     # install_requires=['peppercorn'],
-    install_requires=['boto3', 'lxml', 'requests', 'beautifulsoup4',
-        'configparser', 'tzlocal', 'tabulate', 'keyring', 'six', 'Pillow'],
+    install_requires=['beautifulsoup4', 'boto3', 'configparser', 'keyring',
+        'lxml', 'Pillow', 'requests', 'six', 'tabulate', 'tzlocal'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
@louahola @mide
https://github.com/cevoaustralia/aws-google-auth/pull/91

Some changes to address @mide comments in https://github.com/cevoaustralia/aws-google-auth/pull/91

Not sure if there's a better way to handle the `payload` for `handle_captcha()`, but it at least separates the captcha logic out of the `do_login()` function. 

Noting here that I'm not seeing the captcha request myself currently (Aug 6, 2018), where I did see the captcha request this past Friday (Aug 3, 2018).