### PR TITLE
incorporating feedback for viewing captcha in docker

### DIFF
--- a/aws_google_auth/google.py
+++ b/aws_google_auth/google.py
@@ -312,10 +312,14 @@ class Google:
         captcha_logintoken_audio = captcha_container.find('input', {'name': 'logintoken_audio'}).get('value')
         captcha_url_audio = captcha_container.find('input', {'name': 'url_audio'}).get('value')
 
-        # Open captcha image
-        with requests.get(captcha_url) as url:
-            with io.BytesIO(url.content) as f:
-                Image.open(f).show()
+        # Try to open the image for the user automatically, but if that fails for
+        # any reason, just display the URL for the user to visit.
+        try:
+            with requests.get(captcha_url) as url:
+                with io.BytesIO(url.content) as f:
+                    Image.open(f).show()
+        except Exception:
+            print("Please visit the following URL to view your CAPTCHA: {}".format(captcha_url))
 
         try:
             captcha_input = raw_input("Captcha (case insensitive): ") or None


### PR DESCRIPTION
@louahola @mide @maratsh

Updating captcha open logic to print the URL if `Image.open()` is not available.

https://github.com/cevoaustralia/aws-google-auth/pull/91#issuecomment-411099509